### PR TITLE
Give hidden field in cart form the right name so it populates order

### DIFF
--- a/app/views/spree/products/_variant_options.html.erb
+++ b/app/views/spree/products/_variant_options.html.erb
@@ -25,7 +25,7 @@
       <% index += 1 %>
     <% end %>
 
-    <%= hidden_field_tag "products[#{@product.id}]", "", :id => "variant_id", :class => "hidden" %>
+    <%= hidden_field_tag "variant_id", :id => "products[#{@product.id}]", :class => "hidden" %>
     <script type="text/javascript">
     //<![CDATA[
       var variant_options = new VariantOptions({


### PR DESCRIPTION
Thanks for creating a 2-2-stable branch for this extension!

I tried to use it, but found I couldn't add a variant to the cart. Digging into it, it was because the cart form was sending "products[x] => y" to orders#populate instead of the variant_id. 

Admittedly, I'm not sure of the ramifications of the change I'm making, except that it seems to fix my problem in the limited testing I've done. :-) 

Thought you might want to include this in your 2-2-stable branch. Let me know if you need me to do anything else to make this useful.
