### PR TITLE
fix product show prices

### DIFF
--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -3,11 +3,11 @@ Spree::Variant.class_eval do
   include ActionView::Helpers::NumberHelper
 
   def to_hash
-    price = self.prices.find_by(currency: Spree::Config[:presentation_currency]).display_price.to_html
     price_usd = self.prices.find_by(currency: "USD").display_price.to_html
+    price = display_currency(self.prices.find_by(currency: "USD").display_price, to: 'KRW')
     if self.product.old_price
-      old_price = display_currency(self.product.old_price, to: 'KRW')
       old_price_usd = display_currency(self.product.old_price, to: 'USD')
+      old_price = display_currency(self.product.old_price, to: 'KRW')
     end
     {
       :id => self.id,


### PR DESCRIPTION
fix product show prices in to_hash

previously, some mismatches of product prices.

ex) 
$49.5 > 52209원 - WRONG
$49.5 > 54552원 - CORRECT
