### PR TITLE
Sanitize

### DIFF
--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -3,11 +3,12 @@ Spree::Variant.class_eval do
   include ActionView::Helpers::NumberHelper
 
   def to_hash
-    price = self.prices.find_by(currency: Spree::Config[:presentation_currency]).display_price.to_html
-    price_usd = self.prices.find_by(currency: "USD").display_price.to_html
+    usd = self.prices.find_by(currency: "USD")
+    price = display_currency(usd)
+    price_usd = usd.display_price.to_html
     if self.product.old_price
+      old_price_usd = display_currency(self.product.old_price)
       old_price = display_currency(self.product.old_price, to: 'KRW')
-      old_price_usd = display_currency(self.product.old_price, to: 'USD')
     end
     {
       :id => self.id,

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -3,11 +3,11 @@ Spree::Variant.class_eval do
   include ActionView::Helpers::NumberHelper
 
   def to_hash
-    usd = self.prices.find_by(currency: "USD")
+    usd = self.prices.find_by(currency: 'USD').display_price
+    price_usd = usd.to_html
     price = display_currency(usd)
-    price_usd = usd.display_price.to_html
     if self.product.old_price
-      old_price_usd = display_currency(self.product.old_price)
+      old_price_usd = display_currency(self.product.old_price, to: 'USD')
       old_price = display_currency(self.product.old_price, to: 'KRW')
     end
     {


### PR DESCRIPTION
get rid all of `prices.find_by(currency: "KRW")`

we can fix it now.
https://github.com/casualsteps/luuvit-spree/issues/1129
