### PR TITLE
Refactor variant options to remove hundreds of slow SQL queries.

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -14,10 +14,21 @@ Spree::Product.class_eval do
     @_variants_for_option_value.select { |v| v.in_stock? }
   end
 
+  def variants_by_option
+    variants.includes({option_values: [:option_type]}).each_with_object({}) do |v, result|
+      next if !v.in_stock?
+      v.option_values.each do |o|
+        t = o.option_type
+        result[t] ||= {}
+        (result[t][o] ||= []) << v
+      end
+    end
+  end
+
   def variant_options_hash
     return @_variant_options_hash if @_variant_options_hash
     hash = {}
-    variants.includes({option_values: [:option_type]}, :prices).each do |variant|
+    variants.includes({option_values: [:option_type]}, :default_price).each do |variant|
       variant.option_values.each do |ov|
         otid = ov.option_type_id.to_s
         ovid = ov.id.to_s

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -3,7 +3,7 @@ Spree::Variant.class_eval do
   include ActionView::Helpers::NumberHelper
 
   def to_hash
-    usd = self.prices.find_by(currency: 'USD').display_price
+    usd = self.default_price.display_price
     price_usd = usd.to_html
     price = display_currency(usd)
     if self.product.old_price

--- a/app/views/spree/products/_variant_options.html.erb
+++ b/app/views/spree/products/_variant_options.html.erb
@@ -1,15 +1,15 @@
 <% if @product.has_variants? %>
   <ul id="product-variants">
     <% index = 0 %>
-    <% @product.grouped_option_values.each do |type, values| %>
+    <% @product.variants_by_option.each do |type, values| %>
       <li id="<%= dom_id(type) %>" class="variant-options select" data-index="<%= index %>">
         <select class="variant-option-values">
           <%= content_tag :option do %>
             <%= type.presentation.force_encoding("utf-8") %>를 고르세요
           <% end %>
-          <% values.sort_by{|a| a.name.split(" ")[0].to_i}.each do |value| %>
+          <% values.sort_by{|a, v| a.name}.each do |value, variants| %>
             <% classes = ["option-value"] %>
-            <% unless (variants = @product.variants_for_option_value(value)).empty? %>
+            <% unless variants.empty? %>
               <% classes << ("in-stock") if index == 0 %>
               <%= content_tag :option, value.presentation , :class => classes, :id => "option-#{value.id}" %>
             <% end %>
@@ -20,10 +20,10 @@
       <% index += 1 %>
     <% end %>
 
-    <% active_variants = @product.variants.select { |v| !v.deleted? } %>
-    <% if active_variants.length == 1 %>
+    <% case @product.variants.length %>
+    <% when 1 %>
       <%= hidden_field_tag "variant_id", @product.variants.first.id %>
-    <% elsif active_variants.length == 0 %>
+    <% when 0 %>
       <%= hidden_field_tag "variant_id", @product.master.id %>
     <% else %>
       <%= hidden_field_tag "variant_id", "", :id => "variant_id", :class => "hidden" %>


### PR DESCRIPTION
Instead of generating the hash value -> type -> variant, start from the inverse,
eager loading things as we go. On local, brings queries down from 700 to 38.
